### PR TITLE
updates for hash-to-field from draft-irtf-cfrg-hash-to-curve-06

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "pairing-plus"
 
 # Remember to change version string in README.md.
 
-version = "0.17.1"
+version = "0.18.0"
 authors = [
     # authors of the original pairing library
     "Sean Bowe <ewillbefull@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,15 @@ rand = "0.4"
 byteorder = "1"
 #ff = { version = "0.4", features = ["derive"] }
 #ff = { path = "../ff-fork",  features = ["derive"] }
+digest = "0.8"
 ff = {git = "https://github.com/algorand/ff", features = ["derive"]}
-hkdf = "0.8.0"
-sha2 = "0.8.0"
 zeroize = { version  = "1.1", features = ["zeroize_derive"]}
 rand_core = "0.5"
 rand_xorshift = "0.2"
+
+[dev-dependencies]
+sha2 = "0.8"
+sha3 = "0.8"
 
 [features]
 default = []

--- a/src/bls12_381/fq.rs
+++ b/src/bls12_381/fq.rs
@@ -1,8 +1,7 @@
 use super::fq2::Fq2;
+use digest::generic_array::{typenum::U64, GenericArray};
 use ff::{Field, PrimeField, PrimeFieldDecodingError, PrimeFieldRepr};
 use hash_to_field::BaseFromRO;
-use sha2::digest::generic_array::typenum::U64;
-use sha2::digest::generic_array::GenericArray;
 use signum::{Sgn0Result, Signum0};
 use std::cmp::Ordering;
 use std::io::{Cursor, Read};
@@ -471,7 +470,7 @@ pub const unsafe fn transmute(r: FqRepr) -> Fq {
 }
 
 impl BaseFromRO for Fq {
-    type Length = U64;
+    type BaseLength = U64;
 
     // ZZ note: Convert an output keying material to an Fq element
     // the input generic array is gauranteed to have 64 bytes
@@ -2341,34 +2340,109 @@ fn test_fq_legendre() {
 }
 
 #[test]
-fn test_fq_hash_to_field() {
-    use hash_to_field::HashToField;
+fn test_fq_hash_to_field_xof_shake128() {
+    use hash_to_field::{hash_to_field, ExpandMsgXof};
+    use sha3::Shake128;
 
-    let mut hash_iter = HashToField::<Fq>::new("hello world", None);
-    let fq_val = hash_iter.next().unwrap();
+    let u = hash_to_field::<Fq, ExpandMsgXof<Shake128>>(b"hello world", b"asdfqwerzxcv", 5);
     let expect = FqRepr([
-        0xdfccf585f3c3abu64,
-        0x817786f85a6977d5u64,
-        0x4878057839c2eeb9u64,
-        0xdf824d0b3cacd45cu64,
-        0xac77eef7ea711095u64,
-        0x2457b5ea0140614u64,
+        0xfd18776b48cf1401u64,
+        0x8edc5c3b61702d08u64,
+        0xb8e9894b19cc196bu64,
+        0xd5ffa8c0fca43ec6u64,
+        0x3bbbb9f6b34663c7u64,
+        0x11c8f0f36972173fu64,
     ]);
-    assert_eq!(fq_val, Fq::from_repr(expect).unwrap());
-
-    let fq_val = hash_iter.with_ctr(0);
-    assert_eq!(fq_val, Fq::from_repr(expect).unwrap());
-
-    let fq_val = hash_iter.next().unwrap();
+    assert_eq!(u[0], Fq::from_repr(expect).unwrap());
     let expect = FqRepr([
-        0xe60a4d2be306281eu64,
-        0xf431b0bb0218acdu64,
-        0x2591ca592c870e9cu64,
-        0xd53fc832b7a3eae4u64,
-        0x9d4cbbb85780e0f4u64,
-        0x6ed9a29b5a2f831u64,
+        0xef3f9b8a4baec153u64,
+        0x4a731357bdfad889u64,
+        0xf9dfd6c7da30df38u64,
+        0x935ed115de7b26fdu64,
+        0xf9d565dfc69db96eu64,
+        0x165f801652644c69u64,
     ]);
-    assert_eq!(fq_val, Fq::from_repr(expect).unwrap());
+    assert_eq!(u[1], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0x90c62503451ebfbbu64,
+        0x31cbd57c309155eau64,
+        0xb5139a3122c57601u64,
+        0x487e37e644ff5619u64,
+        0x466d3e60da037f30u64,
+        0x12a9e21536c038bdu64,
+    ]);
+    assert_eq!(u[2], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0xdd50c75afa28549au64,
+        0x63f998ce73ab3f2cu64,
+        0x91dde60ce2b866e0u64,
+        0x142f5244f66f7843u64,
+        0xe1777fedadf76521u64,
+        0xceefaf710c49156u64,
+    ]);
+    assert_eq!(u[3], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0x3d0ade306a80ac3cu64,
+        0xa67656f34e372637u64,
+        0x5823132fda5da8b1u64,
+        0x233d3bcf8742dbdau64,
+        0x2be7d7dce1cb7832u64,
+        0x6aa4625fe15aedcu64,
+    ]);
+    assert_eq!(u[4], Fq::from_repr(expect).unwrap());
+}
+
+#[test]
+fn test_fq_hash_to_field_xmd_sha256() {
+    use hash_to_field::{hash_to_field, ExpandMsgXmd};
+    use sha2::Sha256;
+
+    let u = hash_to_field::<Fq, ExpandMsgXmd<Sha256>>(b"hello world", b"asdfqwerzxcv", 5);
+    let expect = FqRepr([
+        0xd3e7049a0d68fdd5u64,
+        0x6b7d713ff25de8d5u64,
+        0x521c23789786d11fu64,
+        0x59a11d38422a906u64,
+        0x2e875cbbc15586deu64,
+        0x95561c709c5bac2u64,
+    ]);
+    assert_eq!(u[0], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0x66f57d5c74ed4f4au64,
+        0xe3ab3ee234780361u64,
+        0xa8f9d99586347c01u64,
+        0xdbde0c3e0cb2e83fu64,
+        0xd6db38335e21152eu64,
+        0xb9aa72ea01ff932u64,
+    ]);
+    assert_eq!(u[1], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0x2e399fb4fe7a558au64,
+        0x637b9153dba1df73u64,
+        0x1835d6580c0d12a7u64,
+        0x736d8bbbecd1465bu64,
+        0x51b5dee0bdd335ddu64,
+        0xcd8f1cf08a2d1bcu64,
+    ]);
+    assert_eq!(u[2], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0xbeafe0c00936a9e2u64,
+        0xc660c9a32880914fu64,
+        0xbcdc95e89ce8b427u64,
+        0xfd291483392df9bu64,
+        0x8dabd5869c3fbac7u64,
+        0x75fe0cfc52e4fd9u64,
+    ]);
+    assert_eq!(u[3], Fq::from_repr(expect).unwrap());
+    let expect = FqRepr([
+        0x91f8410a518fc4du64,
+        0x97946a05fd862f7u64,
+        0xf10c7034b08d1ec3u64,
+        0x72309ed88b7d4bc2u64,
+        0xff5ccefb6345e749u64,
+        0xfc71cd2f533c8c2u64,
+    ]);
+    assert_eq!(u[4], Fq::from_repr(expect).unwrap());
 }
 
 #[test]

--- a/src/bls12_381/fq2.rs
+++ b/src/bls12_381/fq2.rs
@@ -1,4 +1,8 @@
 use super::fq::{Fq, FROBENIUS_COEFF_FQ2_C1, NEGATIVE_ONE};
+use digest::generic_array::{
+    typenum::{U128, U64},
+    GenericArray,
+};
 use ff::{Field, SqrtField};
 use hash_to_field::{BaseFromRO, FromRO};
 use signum::{Sgn0Result, Signum0};
@@ -220,13 +224,12 @@ impl SqrtField for Fq2 {
 
 /// Fq2 implementation: hash to two elemnts of Fq and combine.
 impl FromRO for Fq2 {
-    fn from_ro<B: AsRef<[u8]>>(input: B, ctr: u8) -> Fq2 {
-        let c0_val = Fq::base_from_ro(input.as_ref(), ctr, 1);
-        let c1_val = Fq::base_from_ro(input.as_ref(), ctr, 2);
-        Fq2 {
-            c0: c0_val,
-            c1: c1_val,
-        }
+    type Length = U128;
+
+    fn from_ro(okm: &GenericArray<u8, U128>) -> Fq2 {
+        let c0 = Fq::from_okm(GenericArray::<u8, U64>::from_slice(&okm[..64]));
+        let c1 = Fq::from_okm(GenericArray::<u8, U64>::from_slice(&okm[64..]));
+        Fq2 { c0, c1 }
     }
 }
 
@@ -984,60 +987,233 @@ fn fq2_field_tests() {
 }
 
 #[test]
-fn test_fq2_hash_to_field() {
+fn test_fq2_hash_to_field_xof_shake128() {
     use super::fq::FqRepr;
     use ff::PrimeField;
-    use hash_to_field::HashToField;
+    use hash_to_field::{hash_to_field, ExpandMsgXof};
+    use sha3::Shake128;
 
-    let mut hash_iter = HashToField::<Fq2>::new("hello world", None);
-    let fq2_val = hash_iter.next().unwrap();
-    let expect_c0 = FqRepr([
-        0xdfccf585f3c3abu64,
-        0x817786f85a6977d5u64,
-        0x4878057839c2eeb9u64,
-        0xdf824d0b3cacd45cu64,
-        0xac77eef7ea711095u64,
-        0x2457b5ea0140614u64,
+    let u = hash_to_field::<Fq2, ExpandMsgXof<Shake128>>(b"hello world", b"asdfqwerzxcv", 5);
+    let c0 = FqRepr([
+        0xcc9186241d29f218u64,
+        0x1c5bde537d5d62d2u64,
+        0xead835ab3858d439u64,
+        0x3acfcbd3280d16adu64,
+        0x22dffb6900bf4db8u64,
+        0x16e64880a0d2ae2eu64,
     ]);
-    let expect_c1 = FqRepr([
-        0x405bf1ab86d10a7au64,
-        0x9d3be7ec3593d32fu64,
-        0x50ab07eeecc60cfdu64,
-        0xf17265f292da13d7u64,
-        0x8f78e998563bf8a6u64,
-        0x4ee3c6a6732ed31u64,
+    let c1 = FqRepr([
+        0xffc1d8959e1fbda4u64,
+        0x15f76c384e299aa4u64,
+        0x95283d9126f1bfafu64,
+        0xc4474dca72ba2ea2u64,
+        0x2ff740be47a00d12u64,
+        0x26a028e0e5c7ec4u64,
     ]);
     let expect = Fq2 {
-        c0: Fq::from_repr(expect_c0).unwrap(),
-        c1: Fq::from_repr(expect_c1).unwrap(),
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
     };
-    assert_eq!(fq2_val, expect);
-
-    let fq2_val = hash_iter.next().unwrap();
-    let expect_c0 = FqRepr([
-        0xe60a4d2be306281eu64,
-        0xf431b0bb0218acdu64,
-        0x2591ca592c870e9cu64,
-        0xd53fc832b7a3eae4u64,
-        0x9d4cbbb85780e0f4u64,
-        0x6ed9a29b5a2f831u64,
+    assert_eq!(u[0], expect);
+    let c0 = FqRepr([
+        0xd7b6366ebb64bf09u64,
+        0x2f19a158fa8c3af7u64,
+        0x25d39882741fb3fcu64,
+        0xb220422e0e7f9f64u64,
+        0x15a18546cc8d0671u64,
+        0xcf3127e75b93f56u64,
     ]);
-    let expect_c1 = FqRepr([
-        0x9c159085a3c31071u64,
-        0xf0acc544e0596fbau64,
-        0xb9ef11375c66a8d9u64,
-        0x594ec2fb229a36bfu64,
-        0xde6047631ce75a1eu64,
-        0x25013f50e2ace23u64,
+    let c1 = FqRepr([
+        0x3a9e8edf8c13d1a2u64,
+        0xefd6d153fbc9e5aeu64,
+        0x2110cb46149e05f3u64,
+        0xd150bacd7c4bb73bu64,
+        0x8fd5964ed718d948u64,
+        0x195db42d0acd4c9cu64,
     ]);
     let expect = Fq2 {
-        c0: Fq::from_repr(expect_c0).unwrap(),
-        c1: Fq::from_repr(expect_c1).unwrap(),
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
     };
-    assert_eq!(fq2_val, expect);
+    assert_eq!(u[1], expect);
+    let c0 = FqRepr([
+        0xf7eda7ae615d4751u64,
+        0xfdc80a1e1fa45e28u64,
+        0xae6ede13f91e88afu64,
+        0xd53258c647e1cf45u64,
+        0x5c7865959951362au64,
+        0x6a71f50733650a3u64,
+    ]);
+    let c1 = FqRepr([
+        0x2dbe88e7e449698u64,
+        0xf5c10f3d656df91du64,
+        0xeb278ac26084cfc2u64,
+        0xe2d64873822caea5u64,
+        0x7e72b2ea4ca500a3u64,
+        0xcb75ade4047c615u64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[2], expect);
+    let c0 = FqRepr([
+        0x212963893850b3efu64,
+        0x67fcf66e241827c7u64,
+        0x96450f830a3bfa7u64,
+        0x228aefe4828f9fedu64,
+        0xd6c2ff61679feeaeu64,
+        0x9ce1e2e602c7091u64,
+    ]);
+    let c1 = FqRepr([
+        0xc975e6116b0d70f7u64,
+        0xf0040ddfc7242b61u64,
+        0x767fb62fdfad7c62u64,
+        0xd6c89b13d56d1a0eu64,
+        0xcd13c174e8e8e0a8u64,
+        0x18b1328571d14a3fu64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[3], expect);
+    let c0 = FqRepr([
+        0xf51365b02cac979bu64,
+        0x95f63b0173bad339u64,
+        0xa0b4c61bdb40ead5u64,
+        0x69134e3b32e9550au64,
+        0x7920ed5dace7061eu64,
+        0x1686d0bb0b08c326u64,
+    ]);
+    let c1 = FqRepr([
+        0xc6d03f25ea042075u64,
+        0x3a562aa6ec077b18u64,
+        0xc7a5f5e57a726880u64,
+        0xc62dc29af5587974u64,
+        0xbd7718bb8b700c6du64,
+        0x1585e426f0cf0fe5u64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[4], expect);
+}
 
-    let fq2_val = hash_iter.with_ctr(1);
-    assert_eq!(fq2_val, expect);
+#[test]
+fn test_fq2_hash_to_field_xmd_sha256() {
+    use super::fq::FqRepr;
+    use ff::PrimeField;
+    use hash_to_field::{hash_to_field, ExpandMsgXmd};
+    use sha2::Sha256;
+
+    let u = hash_to_field::<Fq2, ExpandMsgXmd<Sha256>>(b"hello world", b"asdfqwerzxcv", 5);
+    let c0 = FqRepr([
+        0x30854f240ecb9ea9u64,
+        0x98c7d36765c25b36u64,
+        0x4631f7e0fcf1a3e2u64,
+        0x4468c92363baace4u64,
+        0x2f7f7599933b275du64,
+        0x1103c046a186fbcau64,
+    ]);
+    let c1 = FqRepr([
+        0xafd1082431709f16u64,
+        0x211c1e602f117f4u64,
+        0x10be3007bda0cb91u64,
+        0x15335d40b6efb207u64,
+        0xbf36def94c6ba2e0u64,
+        0xef7f55430bc20d1u64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[0], expect);
+    let c0 = FqRepr([
+        0x59858fc5d6afac97u64,
+        0xc8777bc23f910bd8u64,
+        0x72a366cf274629a2u64,
+        0x1abd6eef2c1837ffu64,
+        0xd9b5e61e6d7c3c65u64,
+        0x5e7b0f1ffab3408u64,
+    ]);
+    let c1 = FqRepr([
+        0x67856becabff040du64,
+        0x22e73f9f7a6c229eu64,
+        0x45490409c38b4c34u64,
+        0x246fe2aed21bf5f2u64,
+        0x5d94167950248592u64,
+        0x39b7b32f71684e4u64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[1], expect);
+    let c0 = FqRepr([
+        0x52513c77de5e99fcu64,
+        0xcd7b0ddd63ddf4ccu64,
+        0xbd5b566687a517b9u64,
+        0xfbeba74bb409b16cu64,
+        0x1603f68ce8121dc7u64,
+        0x1836f8b510c373f8u64,
+    ]);
+    let c1 = FqRepr([
+        0x14de242ebfb26468u64,
+        0x4309160e9c38c96fu64,
+        0x8175bde39c97b660u64,
+        0x81d7e8e4c3c81209u64,
+        0x2380ebc2d1a68072u64,
+        0x2f940b86c60d880u64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[2], expect);
+    let c0 = FqRepr([
+        0x1f91568251cee73du64,
+        0x96988bd027104ae6u64,
+        0x5e1e92aa976ef504u64,
+        0x2f5d984dc7a1333u64,
+        0xc7a88768d9ee084fu64,
+        0xa512fe937586555u64,
+    ]);
+    let c1 = FqRepr([
+        0x71d37d733c13518au64,
+        0xe9c04422a6e87576u64,
+        0x49c238b693b9c1e4u64,
+        0x50d68c0455bb1efau64,
+        0x42f9aa143ca90213u64,
+        0x184bdf4f7c29d95fu64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[3], expect);
+    let c0 = FqRepr([
+        0x64c1d98632043cdeu64,
+        0x384435c3e7e3376au64,
+        0x2d1660332e48f208u64,
+        0xa0ea9e1b6bc12401u64,
+        0x29f74648aa69b26au64,
+        0x26172df0ec4d7f1u64,
+    ]);
+    let c1 = FqRepr([
+        0x80a7bc6ad913e206u64,
+        0xc0a7075fc3702c8cu64,
+        0x38d6881a2beb7440u64,
+        0xf4bc33e1fe0eb2c2u64,
+        0xe3fdb35d9a3621feu64,
+        0x1542ff2b2713e6efu64,
+    ]);
+    let expect = Fq2 {
+        c0: Fq::from_repr(c0).unwrap(),
+        c1: Fq::from_repr(c1).unwrap(),
+    };
+    assert_eq!(u[4], expect);
 }
 
 #[test]

--- a/src/bls12_381/fr.rs
+++ b/src/bls12_381/fr.rs
@@ -1,8 +1,6 @@
+use digest::generic_array::{typenum::U48, GenericArray};
 use ff::{Field, PrimeField, PrimeFieldDecodingError, PrimeFieldRepr};
 use hash_to_field::BaseFromRO;
-
-use sha2::digest::generic_array::typenum::U48;
-use sha2::digest::generic_array::GenericArray;
 use std::io::{Cursor, Read};
 
 #[derive(PrimeField, Zeroize)]
@@ -23,7 +21,7 @@ pub const unsafe fn transmute(r: FrRepr) -> Fr {
 }
 
 impl BaseFromRO for Fr {
-    type Length = U48;
+    type BaseLength = U48;
 
     fn from_okm(okm: &GenericArray<u8, U48>) -> Fr {
         const F_2_192: Fr = Fr(FrRepr([

--- a/src/hash_to_curve.rs
+++ b/src/hash_to_curve.rs
@@ -9,22 +9,26 @@ use CurveProjective;
 type CoordT<PtT> = <PtT as CurveProjective>::Base;
 
 /// Random oracle and injective maps to curve
-pub trait HashToCurve {
+pub trait HashToCurve<X>
+where
+    X: ExpandMsg
+{
     /// Random oracle
-    fn hash_to_curve<X: ExpandMsg>(msg: &[u8], dst: &[u8]) -> Self;
+    fn hash_to_curve<Mt: AsRef<[u8]>, Dt: AsRef<[u8]>>(msg: Mt, dst: Dt) -> Self;
 
     /// Injective encoding
-    fn encode_to_curve<X: ExpandMsg>(msg: &[u8], dst: &[u8]) -> Self;
+    fn encode_to_curve<Mt: AsRef<[u8]>, Dt: AsRef<[u8]>>(msg: Mt, dst: Dt) -> Self;
 }
 
-impl<PtT> HashToCurve for PtT
+impl<PtT, X> HashToCurve<X> for PtT
 where
     PtT: ClearH + IsogenyMap + OSSWUMap,
     CoordT<PtT>: FromRO,
+    X: ExpandMsg,
 {
-    fn hash_to_curve<X: ExpandMsg>(msg: &[u8], dst: &[u8]) -> PtT {
+    fn hash_to_curve<Mt: AsRef<[u8]>, Dt: AsRef<[u8]>>(msg: Mt, dst: Dt) -> PtT {
         let mut p = {
-            let u = hash_to_field::<CoordT<PtT>, X>(msg, dst, 2);
+            let u = hash_to_field::<CoordT<PtT>, X>(msg.as_ref(), dst.as_ref(), 2);
             let mut tmp = PtT::osswu_map(&u[0]);
             tmp.add_assign(&PtT::osswu_map(&u[1]));
             tmp
@@ -34,9 +38,9 @@ where
         p
     }
 
-    fn encode_to_curve<X: ExpandMsg>(msg: &[u8], dst: &[u8]) -> PtT {
+    fn encode_to_curve<Mt: AsRef<[u8]>, Dt: AsRef<[u8]>>(msg: Mt, dst: Dt) -> PtT {
         let mut p = {
-            let u = hash_to_field::<CoordT<PtT>, X>(msg, dst, 1);
+            let u = hash_to_field::<CoordT<PtT>, X>(msg.as_ref(), dst.as_ref(), 1);
             PtT::osswu_map(&u[0])
         };
         p.isogeny_map();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ impl fmt::Display for GroupDecodingError {
             GroupDecodingError::CoordinateDecodingError(description, ref err) => {
                 write!(f, "{} decoding error: {}", description, err)
             }
-            _ => write!(f, "{}", self.description()),
+            _ => write!(f, "{}", self.to_string()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,14 @@
 // Force public structures to implement Debug
 #![deny(missing_debug_implementations)]
 
+extern crate digest;
 extern crate ff;
-extern crate hkdf;
 extern crate rand_core;
 extern crate rand_xorshift;
+#[cfg(test)]
 extern crate sha2;
-
+#[cfg(test)]
+extern crate sha3;
 #[macro_use]
 extern crate zeroize;
 


### PR DESCRIPTION
This PR updates to comply with hash-to-curve version -06.

Ideally, Cargo.toml should depend only on crates from crates.io, whereas right now it's depending on algorand/ff. Is there a plan to fork into ff-plus, too? or perhaps a plan to upstream the zeroize patch to zkcrypto/ff?