### PR TITLE
enable std feature for digest crate ; tweak README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "pairing-plus"
 
 # Remember to change version string in README.md.
 
-version = "0.19.0"
+version = "0.19.1"
 authors = [
     # authors of the original pairing library
     "Sean Bowe <ewillbefull@gmail.com>",
@@ -35,10 +35,13 @@ repository = "https://github.com/algorand/pairing-plus"
 rand = "0.4"
 byteorder = "1"
 ff-zeroize = { version = "0.6.3", features = ["derive"]}
-digest = "0.8"
 zeroize = { version  = "1.1", features = ["zeroize_derive"]}
 rand_core = "0.5"
 rand_xorshift = "0.2"
+
+[dependencies.digest]
+version = "0.8"
+features = ["std"]
 
 [dev-dependencies]
 sha2 = "0.8"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # pairing
 
 [![Crates.io](https://img.shields.io/crates/v/pairing-plus.svg)](https://crates.io/crates/pairing-plus)
-[![Build Status](https://travis-ci.com/algorand/pairing-plus.svg?branch=release-0.17.0)](https://travis-ci.com/algorand/pairing-plus)
+[![Build Status](https://travis-ci.com/algorand/pairing-plus.svg)](https://travis-ci.com/algorand/pairing-plus)
 
 This is a Rust crate for using pairing-friendly elliptic curves. Currently, only the [BLS12-381](https://z.cash/blog/new-snark-curve.html) construction is implemented.
 
-## [Documentation](https://docs.rs/pairing/)
+## [Documentation](https://docs.rs/pairing-plus/)
 
-Bring the `pairing` crate into your project just as you normally would.
+Bring the `pairing-plus` crate into your project just as you normally would.
 
 ## Security Warnings
 


### PR DESCRIPTION
This PR fixes an annoying bug with 0.19.0.

When building or testing this crate directly, everything works fine. However, the crate fails to compile when it's included in an otherwise empty project! The reason is that the `std` feature ends up disabled for the `digest` crate in that case. I'm not quite sure I understand why this happens---I guess my mental model of how Cargo works is wrong.

You can replicate by creating a new project with `cargo init`, adding `pairing = "0.19"` to the dependencies in Cargo.toml, and then trying to `cargo build`. Build will fail. Forcing `digest` to use the `std` feature in the dummy project hides the problem, but the real fix is to change this crate's Cargo.toml (I think).

Also, update a couple lines in the readme.