### PR TITLE
Rand upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ homepage = "https://github.com/algorand/pairing-plus"
 repository = "https://github.com/algorand/pairing-plus"
 
 [dependencies]
-rand = "0.4"
 byteorder = "1"
 ff-zeroize = { version = "0.6.3", features = ["derive"]}
 zeroize = { version  = "1.1", features = ["zeroize_derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,15 @@ repository = "https://github.com/algorand/pairing-plus"
 
 [dependencies]
 byteorder = "1"
-ff-zeroize = { version = "0.6.3", features = ["derive"]}
+#ff-zeroize = { version = "0.6.3", features = ["derive"]}
 zeroize = { version  = "1.1", features = ["zeroize_derive"]}
-rand_core = "0.5"
-rand_xorshift = "0.2"
+rand_core = "0.6"
+rand_xorshift = "0.3"
+
+[dependencies.ff]
+git = "https://github.com/tmpfs/ff-zeroize"
+branch = "rand-upgrade"
+features = ["derive"]
 
 [dependencies.digest]
 version = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 #![deny(missing_debug_implementations)]
 
 extern crate digest;
-extern crate ff_zeroize as ff;
+extern crate ff;
 extern crate rand_core;
 extern crate rand_xorshift;
 #[cfg(test)]


### PR DESCRIPTION
Remove the unused `rand@0.4` dependency and update `rand_core` and `rand_xorshift`.

Once we have a new version of `ff-zeroize` available in `crates.io` we can remove the temporary `git` dependency.